### PR TITLE
Deploy on push/k8s/deploy everywhere

### DIFF
--- a/helm/coco-diamond/templates/daemonset.yaml
+++ b/helm/coco-diamond/templates/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         app: {{ .Values.service.name }} 
         visualize: "true"
     spec:
+      # ensure that diamond will be deployed to all nodes
       tolerations:
       - operator: "Exists"
       containers:

--- a/helm/coco-diamond/templates/daemonset.yaml
+++ b/helm/coco-diamond/templates/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
         app: {{ .Values.service.name }} 
         visualize: "true"
     spec:
+      tolerations:
+      - operator: "Exists"
       containers:
       - name: {{ .Values.service.name }} 
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"


### PR DESCRIPTION
- let diamond be deployed to all nodes, including dedicated kafka, mongo and controller nodes
- see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
- see `coco-system-stats` dashboard 